### PR TITLE
refactor(api building): now use classes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from "axios";
-import { buildMovies, buildShows, Movies, Shows } from "./media";
+import { Movies, Shows } from "./media";
 // api methods
-import { buildUsers, Users } from "./users";
+import { Users } from "./users";
 
 const version = "";
 
@@ -46,6 +46,14 @@ export interface TraktClassSettings extends TraktSettings {
   redirectUri: string;
   apiUrl: string;
   userAgent: string;
+}
+
+/**
+ * Class interface for api namespaces
+ * @internal
+ */
+export interface ApiNamespace {
+  client: AxiosInstance;
 }
 
 /**
@@ -110,8 +118,8 @@ export class Trakt {
       },
     });
 
-    this.users = buildUsers(this.client);
-    this.movies = buildMovies(this.client);
-    this.shows = buildShows(this.client);
+    this.users = new Users(this.client);
+    this.movies = new Movies(this.client);
+    this.shows = new Shows(this.client);
   }
 }

--- a/src/media/index.ts
+++ b/src/media/index.ts
@@ -1,65 +1,63 @@
 import { AxiosInstance } from "axios";
-import {
-  MoviePeople,
-  MovieSummary_Full,
-  ShowPeople,
-  ShowSummary_Full,
-} from "../trakt";
+import { ApiNamespace } from "../client";
+import { MoviePeople, MovieSummary_Full } from "../trakt";
 import { getMoviePeople, getShowPeople } from "./people";
 import { getMovieSummary_Full, getShowSummary_Full } from "./summary";
 
-export interface Shows {
-  summary: (showId: string) => Promise<ShowSummary_Full>;
-  people: (showId: string) => Promise<ShowPeople>;
-}
+/**
+ * Shows api namespace
+ */
+export class Shows implements ApiNamespace {
+  client: AxiosInstance;
 
-export interface Movies {
-  summary: (movieId: string) => Promise<MovieSummary_Full>;
-  people: (movieId: string) => Promise<MoviePeople>;
+  constructor(client: AxiosInstance) {
+    this.client = client;
+  }
+
+  /**
+   * Get details about a show
+   * @param showId show id
+   * @returns
+   */
+  summary(showId: string) {
+    return getShowSummary_Full(this.client, showId);
+  }
+
+  /**
+   * Get people from a show
+   * @param showId show id
+   * @returns
+   */
+  people(showId: string) {
+    return getShowPeople(this.client, showId);
+  }
 }
 
 /**
- *
- * @internal
- * @param client
- * @returns
+ * Movies api namespace
  */
-export function buildShows(client: AxiosInstance): Shows {
-  return {
-    /**
-     * Get details about a show
-     * @param showId
-     * @returns
-     */
-    summary: (showId) => getShowSummary_Full(client, showId),
-    /**
-     * Get people from a show
-     * @param showId
-     * @returns
-     */
-    people: (showId) => getShowPeople(client, showId),
-  };
-}
+export class Movies implements ApiNamespace {
+  client: AxiosInstance;
 
-/**
- *
- * @internal
- * @param client
- * @returns
- */
-export function buildMovies(client: AxiosInstance): Movies {
-  return {
-    /**
-     * Get details about a movie
-     * @param movieId
-     * @returns
-     */
-    summary: (movieId) => getMovieSummary_Full(client, movieId),
-    /**
-     * Get people from a movie
-     * @param movieId
-     * @returns
-     */
-    people: (movieId) => getMoviePeople(client, movieId),
-  };
+  constructor(client: AxiosInstance) {
+    this.client = client;
+  }
+
+  /**
+   * Get details about a movie
+   * @param movieId movie id
+   * @returns
+   */
+  summary(movieId: string) {
+    return getMovieSummary_Full(this.client, movieId);
+  }
+
+  /**
+   * Get people from a movie
+   * @param movieId movie id
+   * @returns
+   */
+  people(movieId: string) {
+    return getMoviePeople(this.client, movieId);
+  }
 }

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,53 +1,36 @@
 import { AxiosInstance } from "axios";
-import { WatchedMovie, WatchedShow } from "../trakt";
+import { ApiNamespace } from "../client";
 import { getWatchedMovies, getWatchedShows } from "./watched";
 
-export interface Users {
-  watched: {
-    movies: (
-      userId: string,
-      accessToken?: string | undefined
-    ) => Promise<WatchedMovie[]>;
-    shows: (
-      /**
-       * Trakt app's client secret
-       */ userId: string,
-      accessToken?: string | undefined
-    ) => Promise<WatchedShow[]>; // api methods
-  };
-}
-
 /**
- *
- * @internal
- * @param client
- * @returns
+ * Users api namespace
  */
-export function buildUsers(client: AxiosInstance): Users {
-  return {
-    /**
-     * Methods to a user's watch history
-     */
-    watched: {
-      /**
-       * Gets a users movie watch history
-       * @param client axios
-       * @param userId trakt user id
-       * @param accessToken oauth access token for private accounts
-       * @returns
-       */
-      movies: (userId: string, accessToken?: string) =>
-        getWatchedMovies(client, userId, accessToken),
+export class Users implements ApiNamespace {
+  client: AxiosInstance;
 
-      /**
-       * Gets a users show watch history
-       * @param client axios
-       * @param userId trakt user id
-       * @param accessToken oauth access token for private accounts
-       * @returns
-       */
-      shows: (userId: string, accessToken?: string) =>
-        getWatchedShows(client, userId, accessToken),
-    },
-  };
+  constructor(client: AxiosInstance) {
+    this.client = client;
+  }
+
+  /**
+   * Gets a users movie watch history
+   * @param client axios
+   * @param userId trakt user id
+   * @param accessToken oauth access token for private accounts
+   * @returns
+   */
+  watchedMovies(userId: string, accessToken?: string) {
+    return getWatchedMovies(this.client, userId, accessToken);
+  }
+
+  /**
+   * Gets a users show watch history
+   * @param client axios
+   * @param userId trakt user id
+   * @param accessToken oauth access token for private accounts
+   * @returns
+   */
+  watchedShows(userId: string, accessToken?: string) {
+    return getWatchedShows(this.client, userId, accessToken);
+  }
 }


### PR DESCRIPTION
Api building now uses classes instead of functions, which would return objects and all the interfaces that come with it.